### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/fastcampus/boardproject/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/boardproject/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.boardproject.repository;
 
 import com.fastcampus.boardproject.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/fastcampus/boardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/boardproject/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.boardproject.repository;
 
 import com.fastcampus.boardproject.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,6 +21,9 @@ spring:
       hibernate.format_sql: true # debug 문장을 한줄이 아닌 format해서 제공한다.
       hibernate.default_batch_fetch_size: 100
   sql.init.mode: always # data.sql파일을 앱실행 시 실행시킬 수 있다.
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated # 우리의 레포를 어디까지 노출시킬지 정한다. annotated는 @Repository가 붙은 레포만 공개한다.
 
 ---
 # 테스트 db용 문서를 따로 작성함

--- a/src/test/java/com/fastcampus/boardproject/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/boardproject/controller/DataRestTest.java
@@ -1,0 +1,95 @@
+package com.fastcampus.boardproject.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+// @WebMvcTest // 슬라이스 테스트, controller 외의 것은 읽지 않는다. datarest의 autoconfig를 읽지 않는다. /// 05.API 테스트 정의 15:00
+@DisplayName("Data REST api 테스트")
+@Transactional // @Transactional을 붙이면 기본동작이 rollback이라 테스트함수가 완료되면 모두 롤백된다.
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest { /// 05.API 테스트 정의 10:00
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    // ⭐️인테그레이션 테스트입니다. 리포지토리까지 실행시켜서 hibernate 쿼리까지 실행한다.
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnArticlesJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articles")) /// 05.API 테스트 정의 12:00 static에 관한 이야기
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+                // .andDo(print());
+
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnArticleJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articles/1")) /// 05.API 테스트 정의 12:00 static에 관한 이야기
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        // .andDo(print());
+
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnArticleCommentsJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articles/1/articleComments")) /// 05.API 테스트 정의 12:00 static에 관한 이야기
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        // .andDo(print());
+
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComments_thenReturnArticleCommentsJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articleComments")) /// 05.API 테스트 정의 12:00 static에 관한 이야기
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        // .andDo(print());
+
+    }
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComment_thenReturnArticleCommentJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articleComments/1")) /// 05.API 테스트 정의 12:00 static에 관한 이야기
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+        // .andDo(print());
+
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 api 들의 존재 여부만 체크하게끔 통합테스트 작성

